### PR TITLE
Fixed type reference to VariableReference

### DIFF
--- a/bundles/org.palladiosimulator.editors.sirius.repository/description/repository.odesign
+++ b/bundles/org.palladiosimulator.editors.sirius.repository/description/repository.odesign
@@ -630,10 +630,10 @@
               <firstModelOperations xsi:type="tool:ChangeContext" browseExpression="var:container">
                 <subModelOperations xsi:type="tool:CreateInstance" typeName="parameter.VariableUsage" referenceName="componentParameterUsage_ImplementationComponentType" variableName="variableUsage">
                   <subModelOperations xsi:type="tool:ChangeContext" browseExpression="var:variableUsage">
-                    <subModelOperations xsi:type="tool:CreateInstance" typeName="parameter::VariableReference" referenceName="namedReference__VariableUsage" variableName="VariableReference"/>
-                    <subModelOperations xsi:type="tool:SetValue" featureName="namedReference__VariableUsage" valueExpression="var:VariableReference"/>
+                    <subModelOperations xsi:type="tool:CreateInstance" typeName="stoex::VariableReference" referenceName="namedReference__VariableUsage" variableName="variableReference"/>
+                    <subModelOperations xsi:type="tool:SetValue" featureName="namedReference__VariableUsage" valueExpression="var:variableReference"/>
                     <subModelOperations xsi:type="tool:ExternalJavaAction" name="Set NamedReference" id="SetNamedReference">
-                      <parameters name="VariableReference" value="var:VariableReference"/>
+                      <parameters name="VariableReference" value="var:variableReference"/>
                     </subModelOperations>
                   </subModelOperations>
                 </subModelOperations>


### PR DESCRIPTION
This PR fixes [EDITORS-232](https://jira.palladio-simulator.com/browse/EDITORS-232). The issue was caused by a wrong type reference as indicated by the thrown exception. The NPE is just a follow-up issue.

We should not merge this PR before 13.11.19.