### PR TITLE
Added missing dependency to target platform.

### DIFF
--- a/releng/org.palladiosimulator.editors.sirius.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.editors.sirius.targetplatform/tp.target
@@ -245,5 +245,13 @@
 <unit id="org.palladiosimulator.examples.package.feature.feature.group" version="tbd"/>
 <repository location="https://updatesite.palladio-simulator.com/palladio-example-models-package/nightly/"/>
 </location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
+<unit id="org.palladiosimulator.cost.feature.feature.group" version="tbd"/>
+<repository location="https://updatesite.palladio-simulator.com/palladio-addons-costefficiency/releases/latest/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
+<unit id="org.palladiosimulator.cost.feature.feature.group" version="tbd"/>
+<repository location="https://updatesite.palladio-simulator.com/palladio-addons-costefficiency/nightly/"/>
+</location>
 </locations>
 </target>


### PR DESCRIPTION
PalladioSimulator/Palladio-Addon-ArchitecturalTemplates#11 initroduced a new dependency that has to be considered here as well.