### PR TITLE
EDITORS-229 Added support for parent data types

### DIFF
--- a/bundles/org.palladiosimulator.editors.sirius.repository/description/repository.odesign
+++ b/bundles/org.palladiosimulator.editors.sirius.repository/description/repository.odesign
@@ -1110,6 +1110,14 @@
             </centerLabelStyleDescription>
           </style>
         </edgeMappings>
+        <edgeMappings name="ParentDataTypeEdge" deletionDescription="//@ownedViewpoints[name='Repository']/@ownedRepresentations[name='Repository%20Diagram']/@additionalLayers[name='DataTypes']/@toolSections.0/@ownedTools[name='ParentDataType%20Deletion']" sourceMapping="//@ownedViewpoints[name='Repository']/@ownedRepresentations[name='Repository%20Diagram']/@additionalLayers[name='DataTypes']/@containerMappings[name='CompositeDataType']" targetMapping="//@ownedViewpoints[name='Repository']/@ownedRepresentations[name='Repository%20Diagram']/@additionalLayers[name='DataTypes']/@containerMappings[name='CompositeDataType']" targetFinderExpression="aql:self.parentType_CompositeDataType" reconnections="//@ownedViewpoints[name='Repository']/@ownedRepresentations[name='Repository%20Diagram']/@additionalLayers[name='DataTypes']/@toolSections.0/@ownedTools[name='ParentDataType%27s%20Target'] //@ownedViewpoints[name='Repository']/@ownedRepresentations[name='Repository%20Diagram']/@additionalLayers[name='DataTypes']/@toolSections.0/@ownedTools[name='ParentDataType%27s%20Source']">
+          <style targetArrow="InputClosedArrow">
+            <strokeColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <centerLabelStyleDescription showIcon="false" labelExpression="&lt;&lt;Inherits>>">
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            </centerLabelStyleDescription>
+          </style>
+        </edgeMappings>
         <containerMappings name="CollectionDataType" deletionDescription="//@ownedViewpoints[name='Repository']/@ownedRepresentations[name='Repository%20Diagram']/@additionalLayers[name='DataTypes']/@toolSections.0/@ownedTools[name='Delete%20CollectionDataType']" labelDirectEdit="//@ownedViewpoints[name='Repository']/@ownedRepresentations[name='Repository%20Diagram']/@defaultLayer/@toolSections.0/@ownedTools[name='Edit%20Name']" semanticCandidatesExpression="feature:dataTypes__Repository" domainClass="repository.CollectionDataType" childrenPresentation="List">
           <subNodeMappings name="InnerType" deletionDescription="//@ownedViewpoints[name='Repository']/@ownedRepresentations[name='Repository%20Diagram']/@additionalLayers[name='DataTypes']/@toolSections.0/@ownedTools[name='Delete%20Inner%20Type']" semanticCandidatesExpression="feature:innerType_CollectionDataType" doubleClickDescription="//@ownedViewpoints[name='Repository']/@ownedRepresentations[name='Repository%20Diagram']/@additionalLayers[name='DataTypes']/@toolSections.0/@ownedTools[name='Edit%20InnerType']" domainClass="repository.DataType">
             <style xsi:type="style:BundledImageDescription" labelExpression="" labelPosition="node" resizeKind="NSEW">
@@ -1232,6 +1240,17 @@
               </firstModelOperations>
             </initialOperation>
           </ownedTools>
+          <ownedTools xsi:type="tool_1:EdgeCreationDescription" name="ParentDataTypeEdge" precondition="aql:preTarget.differs(preSource)" edgeMappings="//@ownedViewpoints[name='Repository']/@ownedRepresentations[name='Repository%20Diagram']/@additionalLayers[name='DataTypes']/@edgeMappings[name='ParentDataTypeEdge']">
+            <sourceVariable name="source"/>
+            <targetVariable name="target"/>
+            <sourceViewVariable name="sourceView"/>
+            <targetViewVariable name="targetView"/>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool:ChangeContext" browseExpression="var:source">
+                <subModelOperations xsi:type="tool:SetValue" featureName="parentType_CompositeDataType" valueExpression="var:target"/>
+              </firstModelOperations>
+            </initialOperation>
+          </ownedTools>
           <ownedTools xsi:type="tool_1:DeleteElementDescription" name="Delete Contains">
             <element name="element"/>
             <elementView name="elementView"/>
@@ -1275,6 +1294,20 @@
                   </subModelOperations>
                 </subModelOperations>
                 <subModelOperations xsi:type="tool:RemoveElement"/>
+              </firstModelOperations>
+            </initialOperation>
+          </ownedTools>
+          <ownedTools xsi:type="tool_1:DeleteElementDescription" name="ParentDataType Deletion">
+            <element name="element"/>
+            <elementView name="elementView"/>
+            <containerView name="containerView"/>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool:Let" variableName="target" valueExpression="[elementView.oclAsType(DEdge).targetNode.oclAsType(DSemanticDecorator).target/]">
+                <subModelOperations xsi:type="tool:Let" variableName="source" valueExpression="[elementView.oclAsType(DEdge).sourceNode.oclAsType(DSemanticDecorator).target/]">
+                  <subModelOperations xsi:type="tool:ChangeContext" browseExpression="aql:source">
+                    <subModelOperations xsi:type="tool:Unset" featureName="parentType_CompositeDataType" elementExpression="aql:target"/>
+                  </subModelOperations>
+                </subModelOperations>
               </firstModelOperations>
             </initialOperation>
           </ownedTools>
@@ -1334,6 +1367,53 @@
                     <parameters name="target" value="var:target"/>
                     <parameters name="otherEnd" value="var:otherEnd"/>
                     <parameters name="instance" value="var:instance"/>
+                  </subModelOperations>
+                </subModelOperations>
+              </firstModelOperations>
+            </initialOperation>
+            <edgeView name="edgeView"/>
+          </ownedTools>
+          <ownedTools xsi:type="tool_1:ReconnectEdgeDescription" name="ParentDataType's Target">
+            <source name="source"/>
+            <target name="target"/>
+            <sourceView name="sourceView"/>
+            <targetView name="targetView"/>
+            <element name="element"/>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool:Let" variableName="currentTarget" valueExpression="var:source">
+                <subModelOperations xsi:type="tool:Let" variableName="currentSource" valueExpression="[edgeView.oclAsType(DEdge).sourceNode.oclAsType(DSemanticDecorator).target/]">
+                  <subModelOperations xsi:type="tool:Let" variableName="newTarget" valueExpression="var:target">
+                    <subModelOperations xsi:type="tool:If" conditionExpression="aql:newTarget.differs(currentSource)">
+                      <subModelOperations xsi:type="tool:ChangeContext" browseExpression="aql:currentSource">
+                        <subModelOperations xsi:type="tool:Unset" featureName="parentType_CompositeDataType" elementExpression="aql:currentTarget"/>
+                        <subModelOperations xsi:type="tool:SetValue" featureName="parentType_CompositeDataType" valueExpression="aql:newTarget"/>
+                      </subModelOperations>
+                    </subModelOperations>
+                  </subModelOperations>
+                </subModelOperations>
+              </firstModelOperations>
+            </initialOperation>
+            <edgeView name="edgeView"/>
+          </ownedTools>
+          <ownedTools xsi:type="tool_1:ReconnectEdgeDescription" name="ParentDataType's Source" reconnectionKind="RECONNECT_SOURCE">
+            <source name="source"/>
+            <target name="target"/>
+            <sourceView name="sourceView"/>
+            <targetView name="targetView"/>
+            <element name="element"/>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool:Let" variableName="currentTarget" valueExpression="[edgeView.oclAsType(DEdge).targetNode.oclAsType(DSemanticDecorator).target/]">
+                <subModelOperations xsi:type="tool:Let" variableName="currentSource" valueExpression="var:source">
+                  <subModelOperations xsi:type="tool:Let" variableName="newSource" valueExpression="var:target">
+                    <subModelOperations xsi:type="tool:If" conditionExpression="aql:newSource.differs(currentTarget)">
+                      <subModelOperations xsi:type="tool:ChangeContext" browseExpression="var:currentSource">
+                        <subModelOperations xsi:type="tool:Unset" featureName="parentType_CompositeDataType" elementExpression="var:currentTarget">
+                          <subModelOperations xsi:type="tool:ChangeContext" browseExpression="aql:newSource">
+                            <subModelOperations xsi:type="tool:SetValue" featureName="parentType_CompositeDataType" valueExpression="var:currentTarget"/>
+                          </subModelOperations>
+                        </subModelOperations>
+                      </subModelOperations>
+                    </subModelOperations>
                   </subModelOperations>
                 </subModelOperations>
               </firstModelOperations>


### PR DESCRIPTION
This PR introduces editing support for parent data types for composite data types in the Sirius editors as requested by [EDITORS-229](https://jira.palladio-simulator.com/browse/EDITORS-229).

Parent data type relations are visualized by an inheritance arrow. Adding, deleting and reconnecting the edge is possible.