### PR TITLE
Editors 278

### DIFF
--- a/bundles/org.palladiosimulator.editors.sirius.assembly.custom/images/operation-required-bottom.svg
+++ b/bundles/org.palladiosimulator.editors.sirius.assembly.custom/images/operation-required-bottom.svg
@@ -35,7 +35,7 @@
    id="namedview7"
    showgrid="false"
    inkscape:zoom="5.9"
-   inkscape:cx="20"
+   inkscape:cx="-54.067796"
    inkscape:cy="20"
    inkscape:window-x="-8"
    inkscape:window-y="-8"
@@ -54,5 +54,5 @@
    d="m 32.549916,31.1 c 0,-7.7 -5.6,-14 -12.5,-14 -6.8,0 -12.4000003,6.1 -12.6000003,13.8"
    id="path4"
    inkscape:connector-curvature="0"
-   style="fill:#ffffff;stroke:#000000;stroke-miterlimit:10" />
+   style="fill:none;stroke:#000000;stroke-miterlimit:10;fill-opacity:0" />
 </svg>

--- a/bundles/org.palladiosimulator.editors.sirius.assembly.custom/images/operation-required-left.svg
+++ b/bundles/org.palladiosimulator.editors.sirius.assembly.custom/images/operation-required-left.svg
@@ -35,7 +35,7 @@
    id="namedview7"
    showgrid="false"
    inkscape:zoom="5.9"
-   inkscape:cx="20"
+   inkscape:cx="-17.033898"
    inkscape:cy="20"
    inkscape:window-x="-8"
    inkscape:window-y="-8"
@@ -54,5 +54,5 @@
    d="m 6.9,32.499913 c 7.7,0 14,-5.6 14,-12.5 0.1,-6.7 -6.1,-12.2999995 -13.7,-12.4999995"
    id="path4"
    inkscape:connector-curvature="0"
-   style="fill:#ffffff;stroke:#000000;stroke-miterlimit:10" />
+   style="fill:none;stroke:#000000;stroke-miterlimit:10" />
 </svg>

--- a/bundles/org.palladiosimulator.editors.sirius.assembly.custom/images/operation-required-right.svg
+++ b/bundles/org.palladiosimulator.editors.sirius.assembly.custom/images/operation-required-right.svg
@@ -35,7 +35,7 @@
    id="namedview7"
    showgrid="false"
    inkscape:zoom="5.9"
-   inkscape:cx="20"
+   inkscape:cx="-17.033898"
    inkscape:cy="20"
    inkscape:window-x="-8"
    inkscape:window-y="-8"
@@ -54,5 +54,5 @@
    d="m 32,7.4500843 c -7.7,0 -14,5.5999997 -14,12.4999997 0,6.8 6.1,12.4 13.8,12.6"
    id="path4"
    inkscape:connector-curvature="0"
-   style="fill:#ffffff;stroke:#000000;stroke-miterlimit:10" />
+   style="fill:none;stroke:#000000;stroke-miterlimit:10" />
 </svg>

--- a/bundles/org.palladiosimulator.editors.sirius.assembly.custom/images/operation-required-top.svg
+++ b/bundles/org.palladiosimulator.editors.sirius.assembly.custom/images/operation-required-top.svg
@@ -35,7 +35,7 @@
    id="namedview7"
    showgrid="false"
    inkscape:zoom="5.9"
-   inkscape:cx="20"
+   inkscape:cx="-17.033898"
    inkscape:cy="20"
    inkscape:window-x="-8"
    inkscape:window-y="-8"
@@ -54,5 +54,5 @@
    d="m 7.4500843,6 c 0,7.7 5.5999997,14 12.4999997,14 6.8,0 12.4,-6.1 12.6,-13.8"
    id="path4"
    inkscape:connector-curvature="0"
-   style="fill:#ffffff;stroke:#000000;stroke-miterlimit:10" />
+   style="fill:none;stroke:#000000;stroke-miterlimit:10" />
 </svg>

--- a/bundles/org.palladiosimulator.editors.sirius.assembly/description/assembly.odesign
+++ b/bundles/org.palladiosimulator.editors.sirius.assembly/description/assembly.odesign
@@ -20,7 +20,7 @@
       </diagramInitialisation>
       <defaultLayer name="Default">
         <edgeMappings name="AssemblyConnector Edge" preconditionExpression="[sourceView.ancestors()->filter(DNodeContainer).target->includes(self.requiringAssemblyContext_AssemblyConnector) and targetView.ancestors()->filter(DNodeContainer).target->includes(self.providingAssemblyContext_AssemblyConnector)/]" semanticCandidatesExpression="[self.connectors__ComposedStructure/]" sourceMapping="//@ownedViewpoints[name='Assembly']/@ownedRepresentations[name='Assembly%20Diagram']/@defaultLayer/@containerMappings[name='ComposedProvidingRequiringEntity%20Node']/@subContainerMappings[name='AssemblyContext%20Container']/@borderedNodeMappings[name='OperationRequiredRole%20Node']" targetMapping="//@ownedViewpoints[name='Assembly']/@ownedRepresentations[name='Assembly%20Diagram']/@defaultLayer/@containerMappings[name='ComposedProvidingRequiringEntity%20Node']/@subContainerMappings[name='AssemblyContext%20Container']/@borderedNodeMappings[name='OperationProvidedRole%20Node']" targetFinderExpression="[self.providedRole_AssemblyConnector/]" sourceFinderExpression="[self.requiredRole_AssemblyConnector/]" domainClass="composition.AssemblyConnector" useDomainElement="true">
-          <style sizeComputationExpression="2">
+          <style lineStyle="dash" sizeComputationExpression="2">
             <strokeColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
             <centerLabelStyleDescription>
               <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
@@ -44,7 +44,7 @@
           </style>
         </edgeMappings>
         <edgeMappings name="AssemblyEventConnector Edge" preconditionExpression="[sourceView.ancestors()->filter(DNodeContainer).target->includes(self.sourceAssemblyContext__AssemblyEventConnector) and targetView.ancestors()->filter(DNodeContainer).target->includes(self.sinkAssemblyContext__AssemblyEventConnector)/]" semanticCandidatesExpression="[self.connectors__ComposedStructure/]" sourceMapping="//@ownedViewpoints[name='Assembly']/@ownedRepresentations[name='Assembly%20Diagram']/@defaultLayer/@containerMappings[name='ComposedProvidingRequiringEntity%20Node']/@subContainerMappings[name='AssemblyContext%20Container']/@borderedNodeMappings[name='SourceRole%20Node']" targetMapping="//@ownedViewpoints[name='Assembly']/@ownedRepresentations[name='Assembly%20Diagram']/@defaultLayer/@containerMappings[name='ComposedProvidingRequiringEntity%20Node']/@subContainerMappings[name='AssemblyContext%20Container']/@borderedNodeMappings[name='SinkRole%20Node']" targetFinderExpression="[self.sinkRole__AssemblyEventConnector/]" sourceFinderExpression="[self.sourceRole__AssemblyEventConnector/]" domainClass="composition.AssemblyEventConnector" useDomainElement="true">
-          <style sizeComputationExpression="2">
+          <style lineStyle="dash" sizeComputationExpression="2">
             <strokeColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
             <centerLabelStyleDescription>
               <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
@@ -68,7 +68,7 @@
           </style>
         </edgeMappings>
         <edgeMappings name="AssemblyInfrastructureConnector Edge" preconditionExpression="[sourceView.ancestors()->filter(DNodeContainer).target->includes(self.requiringAssemblyContext__AssemblyInfrastructureConnector) and targetView.ancestors()->filter(DNodeContainer).target->includes(self.providingAssemblyContext__AssemblyInfrastructureConnector)/]" semanticCandidatesExpression="[connectors__ComposedStructure/]" sourceMapping="//@ownedViewpoints[name='Assembly']/@ownedRepresentations[name='Assembly%20Diagram']/@defaultLayer/@containerMappings[name='ComposedProvidingRequiringEntity%20Node']/@subContainerMappings[name='AssemblyContext%20Container']/@borderedNodeMappings[name='InfrastructureRequiredRole%20Node']" targetMapping="//@ownedViewpoints[name='Assembly']/@ownedRepresentations[name='Assembly%20Diagram']/@defaultLayer/@containerMappings[name='ComposedProvidingRequiringEntity%20Node']/@subContainerMappings[name='AssemblyContext%20Container']/@borderedNodeMappings[name='InfrastructureProvidedRole%20Node']" targetFinderExpression="[providedRole__AssemblyInfrastructureConnector/]" sourceFinderExpression="[requiredRole__AssemblyInfrastructureConnector/]" domainClass="composition.AssemblyInfrastructureConnector" useDomainElement="true">
-          <style sizeComputationExpression="2">
+          <style lineStyle="dash" sizeComputationExpression="2">
             <strokeColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
             <centerLabelStyleDescription>
               <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>

--- a/bundles/org.palladiosimulator.editors.sirius.custom.style/src/org/palladiosimulator/editors/sirius/custom/style/styleconfiguration/ConnectorStyleConfiguration.java
+++ b/bundles/org.palladiosimulator.editors.sirius.custom.style/src/org/palladiosimulator/editors/sirius/custom/style/styleconfiguration/ConnectorStyleConfiguration.java
@@ -1,14 +1,26 @@
 package org.palladiosimulator.editors.sirius.custom.style.styleconfiguration;
 
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gmf.runtime.draw2d.ui.figures.IBorderItemLocator;
+import org.eclipse.sirius.diagram.DNode;
+import org.eclipse.sirius.diagram.ui.tools.api.figure.locator.DBorderItemLocator;
 import org.eclipse.sirius.diagram.ui.tools.api.graphical.edit.styles.SimpleStyleConfiguration;
 import org.eclipse.sirius.ext.gmf.runtime.gef.ui.figures.util.AnchorProvider;
 
 public class ConnectorStyleConfiguration extends SimpleStyleConfiguration {
 
+    private final static int MAX_LABEL_DISTANCE = 50;
+
     AnchorProvider anchorProvider;
 
     /**
-     * Creates a StyleConfiguration for providing anchors for a connector
+     * Creates a StyleConfiguration for providing anchors for a connector.<br>
+     * Furthermore it changes the Label positioning to make the Labels freely draggable.
      *
      * @param anchorProvider
      *            the provider for the specific anchortype
@@ -20,5 +32,71 @@ public class ConnectorStyleConfiguration extends SimpleStyleConfiguration {
     @Override
     public AnchorProvider getAnchorProvider() {
         return this.anchorProvider;
+    }
+
+    @Override
+    public IBorderItemLocator getNameBorderItemLocator(final DNode node, final IFigure mainFigure) {
+        final IBorderItemLocator locator = super.getNameBorderItemLocator(node, mainFigure);
+        return new FreeDraggableBorderItemLocator(mainFigure, locator.getCurrentSideOfParent());
+    }
+
+    /**
+     * A BorderItemLocator for Labels that should be freely draggable. <br>
+     * <br>
+     * Labels can be dragged to a maximal distance of MAX_LABEL_DISTANCE (50 Pixels) away from the
+     * node.
+     *
+     * @author Jonas Lehmann
+     */
+    private class FreeDraggableBorderItemLocator extends DBorderItemLocator {
+
+        /**
+         * Creates a new {@link FreeDraggableBorderItemLocator}.
+         *
+         * @param parentFigure
+         *            The Parent Node to which the label belongs to
+         * @param preferredSide
+         *            The preferred side
+         */
+        public FreeDraggableBorderItemLocator(final IFigure parentFigure, final int preferredSide) {
+            super(parentFigure, preferredSide);
+        }
+
+        @Override
+        public void relocate(final IFigure borderItem) {
+            final Rectangle parentBounds = this.getParentFigure()
+                .getBounds()
+                .getCopy();
+            if (!(parentBounds.x == 0 && parentBounds.y == 0 && parentBounds.width <= 0 && parentBounds.height <= 0)) {
+                super.relocate(borderItem);
+                final Point newLocation = this.translateIntoBounds(this.getPreferredLocation(borderItem), parentBounds,
+                        borderItem.getBounds());
+                borderItem.setLocation(newLocation);
+            }
+        }
+
+        @Override
+        public Rectangle getValidLocation(final Rectangle proposedLocation, final IFigure borderItem,
+                final Collection<IFigure> figuresToIgnore, final List<IFigure> additionalFiguresForConflictDetection) {
+            return this.getValidLocation(proposedLocation, borderItem);
+        }
+
+        @Override
+        public Rectangle getValidLocation(final Rectangle proposedLocation, final IFigure borderItem) {
+            final Point newLocation = this.translateIntoBounds(proposedLocation.getTopLeft(), this.getParentFigure()
+                .getBounds(), borderItem.getBounds());
+            return proposedLocation.setLocation(newLocation);
+        }
+
+        private Point translateIntoBounds(final Point location, final Rectangle parentBounds,
+                final Rectangle borderItemBounds) {
+            final int width = borderItemBounds.width();
+            final int height = borderItemBounds.height();
+            location.setX(Math.max(parentBounds.getLeft().x - MAX_LABEL_DISTANCE - width,
+                    (Math.min(parentBounds.getRight().x + MAX_LABEL_DISTANCE, location.x))));
+            location.setY(Math.max(parentBounds.getTop().y - MAX_LABEL_DISTANCE - height,
+                    (Math.min(parentBounds.getBottom().y + MAX_LABEL_DISTANCE, location.y))));
+            return location;
+        }
     }
 }


### PR DESCRIPTION
This Pull Request targets all open topics of Issue 278 (https://palladio-simulator.atlassian.net/browse/EDITORS-278).
The problem with the anchor points has already been solved in Issue 225.

In this PR, the RequiredRoles transparency issues have now been fixed and the Edges of all Assembly Connectors have been set to dashed: AssemblyConnector, AssemblyEventConnector and AssemblyInfrastructureConnector.

In addition, labels are now freely movable, within a 50 pixel surrounding of the node. This feature is provided by implementing an own FreeDraggableBorderItemLocator in the ConnectorStyleConfiguration.